### PR TITLE
fix: update indents.scm to use Zed's documented pattern

### DIFF
--- a/languages/nu/indents.scm
+++ b/languages/nu/indents.scm
@@ -1,29 +1,16 @@
 ; Forked from https://github.com/nushell/tree-sitter-nu
 ; Copyright (c) 2019 - 2022 The Nushell Project Developers
 ; Licensed under the MIT license.
-[
-  (expr_parenthesized)
-  (parameter_bracks)
-  (ctrl_match)
 
-  (val_record)
-  (val_list)
-  (val_closure)
-  (val_table)
+; Changed to follow Zed's documented pattern
 
-  (block)
-] @indent.begin
+(expr_parenthesized ")" @end) @indent
+(parameter_bracks "]" @end) @indent
+(ctrl_match) @indent
 
-[
-  "}"
-  "]"
-  ")"
-] @indent.end
+(val_record "}" @end) @indent
+(val_list "]" @end) @indent
+(val_closure "}" @end) @indent
+(val_table "]" @end) @indent
 
-[
-  "}"
-  "]"
-  ")"
-] @indent.branch
-
-(comment) @indent.auto
+(block "}" @end) @indent


### PR DESCRIPTION
## Problem
The current `indents.scm` file uses `@indent.begin`/`@indent.end` syntax which doesn't work correctly with Zed's current indentation system, causing auto-indentation to fail for Nu language files.  

## Solution  
Updated the indentation rules to use Zed's documented `@indent`/`@end` anchor pattern as described in their tree-sitter indentation guide.

## Changes
- Converted from `@indent.begin`/`@indent.end` to `@indent`/`@end` anchors
- Removed unused `@indent.branch` and `@indent.auto` rules  
- Added specific end tokens for each construct (e.g., `"}"`, `"]"`, `")"`)

## Testing
Tested with Nu files in Zed - auto-indentation now works correctly, or at least in line with the behavior that I expect to see.

