### PR TITLE
Fix highlighting of comments

### DIFF
--- a/languages/nu/highlights.scm
+++ b/languages/nu/highlights.scm
@@ -266,9 +266,9 @@ key: (identifier) @property
 
 (shebang) @keyword.directive
 (comment) @comment
-((comment)+ @comment.documentation @spell
+((comment)+ @comment.documentation
   .
   (decl_def))
 
 (parameter
-  (comment) @comment.documentation @spell)
+  (comment) @comment.documentation)


### PR DESCRIPTION
Closes https://github.com/zed-extensions/nu/issues/11

The issue here is that `syntax.spell` is not defined in any theme, but causes the preceding comment highlighting to be overridden and thus lost. We then just fallback to the default text color, which is white. This PR fixes this by removing the `@spell` capture, which ensures proper highlighting.

| Before | After |
| --- | --- |
| <img width="504" height="149" alt="image" src="https://github.com/user-attachments/assets/e10cccda-e6c0-49eb-a556-198061e570a9" /> | <img width="504" height="149" alt="image" src="https://github.com/user-attachments/assets/c2bbc17c-86d2-4afb-a260-17d1cd8b775c" /> |

(We don't talk about the typo in the image..)
